### PR TITLE
PF-9: Added a min-height to the Header

### DIFF
--- a/src/components/UI/Header/Header.component.jsx
+++ b/src/components/UI/Header/Header.component.jsx
@@ -56,6 +56,7 @@ const HeaderContainer = styled.header`
   box-shadow: 0 5px 8px -9px rgba(0, 0, 0, 0.75);
   display: flex;
   height: 8vh;
+  min-height: 65px;
   justify-content: center;
   position: sticky;
   top: 0;


### PR DESCRIPTION
Added a min-height of 65px to the  Header to enable mobile responsiveness.
[UX/UI: Header needs to be a constant height](https://app.gitkraken.com/glo/card/388b907d9cd44f0f8059a13e32da9d88)